### PR TITLE
[FIX] Minor change to avoid ambiguity between method and signal

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ def callback(success):
     print("Did login succeed? Answer: %s" % success)
 
 widget = Login()
-widget.on_login.connect(callback)
+widget.on_login_signal.connect(callback)
 widget.show()
 ```
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ def callback(success):
     print("Did login succeed? Answer: %s" % success)
 
 widget = Login()
-widget.on_login_signal.connect(callback)
+widget.logged_in.connect(callback)
 widget.show()
 ```
 

--- a/qtazu/widgets/login.py
+++ b/qtazu/widgets/login.py
@@ -134,4 +134,4 @@ class Login(QtWidgets.QDialog):
             name = "{user[first_name]} {user[last_name]}".format(**result)
             log.info("Logged in as %s.." % name)
             self.on_login_signal.emit(True)
-            self.accept()
+        self.accept()

--- a/qtazu/widgets/login.py
+++ b/qtazu/widgets/login.py
@@ -10,7 +10,7 @@ log = logging.getLogger(__name__)
 class Login(QtWidgets.QDialog):
     """Log-in dialog to CG-Wire"""
 
-    on_login = QtCore.Signal(bool)
+    on_login_signal = QtCore.Signal(bool)
 
     def __init__(self, parent=None, initialize_host=True):
         super(Login, self).__init__(parent)
@@ -127,12 +127,11 @@ class Login(QtWidgets.QDialog):
 
             self.error.setText(message)
             self.error.show()
-            self.on_login.emit(False)
+            self.on_login_signal.emit(False)
             return
 
         if result:
             name = "{user[first_name]} {user[last_name]}".format(**result)
             log.info("Logged in as %s.." % name)
-            self.on_login.emit(True)
-
-        self.accept()
+            self.on_login_signal.emit(True)
+            self.accept()

--- a/qtazu/widgets/login.py
+++ b/qtazu/widgets/login.py
@@ -10,7 +10,7 @@ log = logging.getLogger(__name__)
 class Login(QtWidgets.QDialog):
     """Log-in dialog to CG-Wire"""
 
-    on_login_signal = QtCore.Signal(bool)
+    logged_in = QtCore.Signal(bool)
 
     def __init__(self, parent=None, initialize_host=True):
         super(Login, self).__init__(parent)
@@ -127,11 +127,11 @@ class Login(QtWidgets.QDialog):
 
             self.error.setText(message)
             self.error.show()
-            self.on_login_signal.emit(False)
+            self.logged_in.emit(False)
             return
 
         if result:
             name = "{user[first_name]} {user[last_name]}".format(**result)
             log.info("Logged in as %s.." % name)
-            self.on_login_signal.emit(True)
+            self.logged_in.emit(True)
         self.accept()


### PR DESCRIPTION
A method and a signal in the `Login` class are named the same, which causes confusion when calling them.

With this PR, the signal is renamed, avoiding ambiguity.